### PR TITLE
added compatibility to python-openhab 2.14 and higher

### DIFF
--- a/nuimo_openhab/app_builder.py
+++ b/nuimo_openhab/app_builder.py
@@ -5,7 +5,7 @@ from nuimo_openhab.listener import *
 
 
 class OpenHabAppBuilder:
-    def __init__(self, openhab : openHAB, sitemapName = "nuimo"):
+    def __init__(self, openhab : OpenHAB, sitemapName = "nuimo"):
         self.openhab = openhab
         self.sitemapName = sitemapName
         self.sitemap = dict()

--- a/nuimo_openhab/listener.py
+++ b/nuimo_openhab/listener.py
@@ -6,7 +6,7 @@ from nuimo_openhab.util.threading import synchronized
 
 import nuimo
 import requests
-from openhab import openHAB
+from openhab import OpenHAB
 
 import nuimo_menue
 from nuimo_openhab.util import config
@@ -14,7 +14,7 @@ from nuimo_openhab.util import config
 
 class OpenHabItemListener(nuimo_menue.model.AppListener):
 
-    def __init__(self, openhab: openHAB):
+    def __init__(self, openhab: OpenHAB):
         self.openhab = openhab
         self.widgets = []
         self.sliderWidgets = []


### PR DESCRIPTION
python-openhab changed the variable "openHAB" to "OpenHAB" with version 2.14, so the import and initial call has to be changed

Maybe add the restriction for the version >= 2.14 of python-openhab in the requirements.txt too. But I didn't check any further compatibility.